### PR TITLE
Fix cloud shell notebook link

### DIFF
--- a/fastai.sh
+++ b/fastai.sh
@@ -317,7 +317,7 @@ show_jupyter_link () {
   echo -ne "Waiting for Jupyter "
   wait_for_command "fastai-1" "curl http://localhost:8080"
 
-  external_ip=$(gcloud compute --project=$DEVSHELL_PROJECT_ID instances list | grep fastai-1 | sed 's/  */ /g' | cut -d ' ' -f6)
+  external_ip=$(gcloud compute --project=$DEVSHELL_PROJECT_ID instances list | grep fastai-1 | sed 's/  */ /g' | cut -d ' ' -f5)
   echo "Access notebooks via http://${external_ip}:8080"
 }
 


### PR DESCRIPTION
Hi Arunoda! Thanks for writing this handy tool for the fastai course! I found a small bug in the code, and I thought "this would be a great opportunity to teach myself how to properly do a pull request, and to make a tiny contribution." 😁 

Here's a picture showing the bug:
![fastai-shell-bug](https://user-images.githubusercontent.com/32517902/84902693-6cd5c080-b0ad-11ea-9438-dedf5c12d87f.png)

The link to jupyter notebook is not showing up correctly in cloud shell due
to an incorrectly indexed column, which led to the status ("RUNNING") being stored
as the external_ip rather than the actual external ip. This commit
simply changes the number of the indexed column from '6' to '5'. This
should result in the correct notebook link being printed to the
terminal.

Have a great day, and happy deep learning! ✌️ 

Markus